### PR TITLE
Add MIT LICENSE (closes part of #8)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Cryptohopper B.V.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

The repo has no top-level LICENSE file. The Node `package.json` declares `"ISC"` but no LICENSE ships; the README is silent on terms. Issue #8 flagged this alongside the unrelated Node-deps CVE situation.

This PR adds an MIT license — matching every other public repository in the cryptohopper org (Node, Python, Go, Ruby, Rust, PHP, Dart, Swift, Kotlin SDKs, and the CLI are all MIT). Users can now copy-paste these samples into their own MIT or Apache-2.0 projects without licensing friction.

## Out of scope

The other half of #8 — bumping the Node sample's deps to fix the open CVEs — needs a deeper rewrite (axios `0.21.x` → `1.x` is a major-version bump). Left for a separate PR.

## Test plan

- [x] `LICENSE` exists at repo root
- [x] Standard MIT body, copyright Cryptohopper B.V.

🤖 Generated with [Claude Code](https://claude.com/claude-code)