### PR TITLE
Fix two bugs in php/api_request.php

### DIFF
--- a/php/api_request.php
+++ b/php/api_request.php
@@ -1,13 +1,18 @@
 <?php
 $access_token = 'ENTER_YOUR_ACCESS_TOKEN';
+$api_url = 'https://api.cryptohopper.com';
 $operation = 'hopper';
 $method = 'GET';
 $data_string = '{}';
 
 $path = '/v1/'.$operation;
 
+// Cryptohopper Public API v1 uses the `access-token` header (with a
+// hyphen), NOT `access_token` and NOT `Authorization: Bearer`. The AWS
+// API Gateway in front of the production API rejects anything else.
+// See https://www.cryptohopper.com/api-documentation/how-the-api-works
 $headers = array(
-    'access_token: '.$access_token
+    'access-token: '.$access_token
 );
 
 $ch = curl_init($api_url.$path);


### PR DESCRIPTION
## Summary

`php/api_request.php` has two bugs that together mean the sample cannot have worked end-to-end as published:

1. **Wrong auth header.** Line 10 sent `access_token:` (underscore). The Cryptohopper public API v1 expects `access-token:` (hyphen) — the AWS API Gateway in front of the production API returns `405 Missing Authentication Token` otherwise. Same gotcha that ate hours when shipping the new SDKs.
2. **Undefined `\$api_url`.** Line 13 references `\$api_url` but it's never defined in this script. PHP would warn and `curl_init` would silently produce a malformed URL.

`php/api_test.php` in the same directory already has the correct header — the two files diverged when one was updated and the other wasn't.

## Diff

```diff
+$api_url = 'https://api.cryptohopper.com';
 ...
 $headers = array(
-    'access_token: '.$access_token
+    'access-token: '.$access_token
 );
```

Plus an inline comment pointing to [How the API Works](https://www.cryptohopper.com/api-documentation/how-the-api-works) so the next reader sees the rule.

## Test plan

- [x] Static review of the diff against `api_test.php` (which already had the correct header).
- [ ] End-to-end against the live API — needs a real bearer token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)