### PR TITLE
Bands 2 & 3: recipes, OAuth flows, webhooks, CLI scripting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Practical, runnable examples for the [Cryptohopper](https://www.cryptohopper.com
 | [`quickstart/`](./quickstart/) | A "hello world" per language — authenticate and make one API call. Pick this if you're new. |
 | [`oauth/`](./oauth/) | Drive the three-leg OAuth2 consent flow end to end (server-side apps that need to obtain tokens for users). |
 | [`webhooks/`](./webhooks/) | Receive webhook events from Cryptohopper (order fills, signals). |
-| [`recipes/`](./recipes/) | Cross-language patterns: poll a backtest, fan out positions, retry strategy, stream new fills. *(coming in the next batch)* |
-| [`cli/`](./cli/) | Shell scripts that combine `cryptohopper` CLI commands with `jq` for ops automation. *(coming in the next batch)* |
+| [`recipes/`](./recipes/) | Cross-language patterns: poll a backtest, fan out positions, retry strategy, stream new fills. |
+| [`cli/`](./cli/) | Shell scripts that combine `cryptohopper` CLI commands with `jq` for ops automation. |
 
 ## Browse by language
 
@@ -20,7 +20,7 @@ Every official Cryptohopper SDK ships an alpha-quality "0.x" release on its nati
 |----------|-----------|-----------|----------|
 | **Node.js** | [`quickstart/nodejs/`](./quickstart/nodejs/) | [`oauth/nodejs/`](./oauth/nodejs/) | [`@cryptohopper/sdk`](https://www.npmjs.com/package/@cryptohopper/sdk) |
 | **Python** | [`quickstart/python/`](./quickstart/python/) | [`oauth/python/`](./oauth/python/) | [`cryptohopper`](https://pypi.org/project/cryptohopper/) |
-| **Go** | [`quickstart/go/`](./quickstart/go/) | — | [`cryptohopper-go-sdk`](https://pkg.go.dev/github.com/cryptohopper/cryptohopper-go-sdk) |
+| **Go** | [`quickstart/go/`](./quickstart/go/) | [`oauth/go/`](./oauth/go/) | [`cryptohopper-go-sdk`](https://pkg.go.dev/github.com/cryptohopper/cryptohopper-go-sdk) |
 | **Ruby** | [`quickstart/ruby/`](./quickstart/ruby/) | — | [`cryptohopper`](https://rubygems.org/gems/cryptohopper) |
 | **Rust** | [`quickstart/rust/`](./quickstart/rust/) | — | [`cryptohopper`](https://crates.io/crates/cryptohopper) |
 | **PHP** | [`quickstart/php/`](./quickstart/php/) | [`oauth/php/`](./oauth/php/) | [`cryptohopper/sdk`](https://packagist.org/packages/cryptohopper/sdk) |

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,64 @@
+# CLI scripting recipes
+
+Short Bash scripts that wrap the [`cryptohopper` CLI](https://github.com/cryptohopper/cryptohopper-cli) for ops and automation. Every script uses `--json` output piped into `jq` — no SDK code, no language runtime, just `bash`/`jq`/`cryptohopper`.
+
+## Scripts
+
+| Script | What it does |
+|--------|--------------|
+| [`monitor-positions.sh`](./monitor-positions.sh) | Live `watch`-style display of open positions across every hopper |
+| [`batch-backtests.sh`](./batch-backtests.sh) | Submit backtests for every hopper in parallel, poll until all finish |
+
+## Requirements
+
+- The [`cryptohopper`](https://github.com/cryptohopper/cryptohopper-cli) CLI, signed in (`cryptohopper login`).
+- `jq` for JSON parsing.
+- `bash` 4+ (or any POSIX-ish shell — most of these will work in `zsh` and `dash`).
+
+## Why CLI scripting instead of an SDK?
+
+For ops tasks that:
+
+- Run on shared infra without a Node/Python/Go runtime
+- Need to be readable by anyone on the team (no language barrier)
+- Compose well with other Unix tools (`watch`, `cron`, `xargs`, etc.)
+
+…the CLI is the right level. Once your script grows past ~50 lines or you need real error handling, switch to one of the SDKs.
+
+## Pattern: every CLI command supports `--json`
+
+Every `cryptohopper` subcommand accepts `--json` and emits a stable shape:
+
+```json
+{
+  "ok": true,
+  "data": <result>
+}
+```
+
+On error:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "RATE_LIMITED",
+    "message": "...",
+    "retry_after_ms": 1000
+  }
+}
+```
+
+So `jq -r '.data.id'` works after any successful command, and `jq -r '.error.code'` after any failed one. The exit-code contract is: 0 = ok, 1 = generic error, 2 = rate-limited, 3 = auth error.
+
+## Pattern: pipe into `xargs` or a `while read`
+
+```bash
+# Run something for every hopper:
+cryptohopper hoppers list --json | jq -r '.data[].id' \
+  | while read -r id; do
+      # ... per-hopper work ...
+    done
+```
+
+That's the spine of every script in this directory.

--- a/cli/batch-backtests.sh
+++ b/cli/batch-backtests.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Submit backtests for every hopper in parallel, then poll until all are done.
+#
+# Reads a date range from $FROM and $TO, lists all hoppers, submits one
+# backtest per hopper, then polls each in a loop until terminal status.
+# Output is one summary line per backtest.
+#
+# Requires: cryptohopper CLI, jq.
+#
+# Run:
+#   export FROM=2026-01-01
+#   export TO=2026-04-01
+#   ./batch-backtests.sh
+
+set -euo pipefail
+
+command -v cryptohopper >/dev/null || { echo "Install the cryptohopper CLI first." >&2; exit 1; }
+command -v jq >/dev/null || { echo "Install jq first." >&2; exit 1; }
+
+: "${FROM:?Set FROM=YYYY-MM-DD}"
+: "${TO:?Set TO=YYYY-MM-DD}"
+
+echo "Submitting backtests for every hopper, $FROM → $TO…" >&2
+
+# 1. Submit one backtest per hopper. Save (hopper_id, backtest_id) pairs.
+mapping=$(mktemp)
+trap 'rm -f "$mapping"' EXIT
+
+cryptohopper hoppers list --json \
+  | jq -r '.data[].id' \
+  | while read -r hopper_id; do
+      bt_id=$(
+        cryptohopper backtest new "$hopper_id" --from "$FROM" --to "$TO" --json \
+          | jq -r '.data.id'
+      )
+      printf '%s\t%s\n' "$hopper_id" "$bt_id" >> "$mapping"
+      echo "  hopper=$hopper_id backtest=$bt_id submitted" >&2
+      # The backtest bucket is 1 req/2s; pace.
+      sleep 3
+    done
+
+echo >&2
+echo "Polling…" >&2
+
+# 2. Poll each backtest until terminal.
+while IFS=$'\t' read -r hopper_id bt_id; do
+  while :; do
+    status=$(cryptohopper backtest status "$bt_id" --json | jq -r '.data.status')
+    case "$status" in
+      completed)
+        profit=$(cryptohopper backtest status "$bt_id" --json | jq -r '.data.profit_pct // .data.profit // "?"')
+        printf '%s\thopper=%s\tbacktest=%s\tprofit=%s\n' "$status" "$hopper_id" "$bt_id" "$profit"
+        break
+        ;;
+      failed)
+        printf '%s\thopper=%s\tbacktest=%s\n' "$status" "$hopper_id" "$bt_id"
+        break
+        ;;
+    esac
+    sleep 5
+  done
+done < "$mapping"

--- a/cli/monitor-positions.sh
+++ b/cli/monitor-positions.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Monitor open positions across every hopper, refreshed every 30 seconds.
+#
+# Combines `cryptohopper hoppers list --json` to enumerate hoppers with
+# `cryptohopper positions <id> --json` to fetch each hopper's positions,
+# then formats with jq into a single rolling table.
+#
+# Requires: cryptohopper CLI, jq.
+#
+# Run:
+#   chmod +x monitor-positions.sh
+#   ./monitor-positions.sh
+
+set -euo pipefail
+
+command -v cryptohopper >/dev/null || { echo "Install the cryptohopper CLI first." >&2; exit 1; }
+command -v jq >/dev/null || { echo "Install jq first." >&2; exit 1; }
+
+INTERVAL_S="${INTERVAL_S:-30}"
+
+while :; do
+  clear
+  printf 'Cryptohopper position monitor — %s (refresh every %ss, Ctrl-C to exit)\n\n' "$(date)" "$INTERVAL_S"
+  printf '%-10s  %-25s  %-15s  %-12s  %-15s\n' 'HOPPER' 'NAME' 'COIN' 'AMOUNT' 'RATE'
+  printf '%-10s  %-25s  %-15s  %-12s  %-15s\n' '------' '----' '----' '------' '----'
+
+  cryptohopper hoppers list --json \
+    | jq -r '.data[] | "\(.id)\t\(.name // "?")"' \
+    | while IFS=$'\t' read -r hopper_id hopper_name; do
+        cryptohopper positions "$hopper_id" --json 2>/dev/null \
+          | jq -r --arg id "$hopper_id" --arg name "$hopper_name" '
+              .data[]?
+              | "\($id)\t\($name)\t\(.coin // "?")\t\(.amount // "?")\t\(.rate // "?")"
+            ' \
+          | while IFS=$'\t' read -r id name coin amount rate; do
+              printf '%-10s  %-25s  %-15s  %-12s  %-15s\n' "$id" "$name" "$coin" "$amount" "$rate"
+            done
+      done
+
+  sleep "$INTERVAL_S"
+done

--- a/oauth/go/README.md
+++ b/oauth/go/README.md
@@ -1,0 +1,47 @@
+# Go OAuth flow
+
+A minimal `net/http` server that drives the three-leg OAuth2 authorization-code flow against [cryptohopper.com](https://www.cryptohopper.com), then calls one authenticated endpoint on `api.cryptohopper.com` to confirm the token works.
+
+## Requirements
+
+- Go 1.22+
+- A Cryptohopper [developer-app](https://www.cryptohopper.com) `client_id` and `client_secret`
+- Stdlib only — no third-party deps (`go.mod` has no `require` block).
+
+## Run it
+
+```bash
+export CRYPTOHOPPER_CLIENT_ID=your-40-char-client-id
+export CRYPTOHOPPER_CLIENT_SECRET=your-client-secret
+
+go run main.go
+```
+
+Then open <http://localhost:3000/auth> in a browser. After the consent flow you'll be redirected back to `/` which calls `GET /v1/hopper` and prints the response.
+
+## What the three endpoints do
+
+| Path | Purpose |
+|------|---------|
+| `/` | Protected resource. With a token, calls `GET /v1/hopper` and returns the JSON. Without one, links to `/auth`. |
+| `/auth` | Generates a CSRF state, stashes it, redirects to `cryptohopper.com/oauth2/authorize`. |
+| `/callback` | Verifies state, receives the auth code, exchanges it for an access token, redirects to `/`. |
+
+## Production notes
+
+This sample stores `accessToken` and `expectedState` in process-local globals for clarity. Real apps should:
+
+- Persist tokens per session (cookie + session store).
+- Persist `state` per session, not in a global — single-state-per-process means concurrent OAuth flows collide.
+- Refresh tokens via `grant_type=refresh_token` when the access token expires.
+
+## Production alternative — use the SDK
+
+For most production apps you'd drive the OAuth flow once at app-bootstrap time (or via the `cryptohopper login` CLI) and pass the resulting bearer to the SDK:
+
+```go
+ch, _ := cryptohopper.NewClient(token)
+hoppers, _ := ch.Hoppers.List(ctx, nil)
+```
+
+The SDK handles retry, error mapping, and the access-token header. This sample is intentionally low-level so you can see what the SDK does for you.

--- a/oauth/go/go.mod
+++ b/oauth/go/go.mod
@@ -1,0 +1,3 @@
+module oauth-sample
+
+go 1.22

--- a/oauth/go/main.go
+++ b/oauth/go/main.go
@@ -1,0 +1,162 @@
+// Cryptohopper OAuth2 sample (Go) — three-leg authorization-code flow.
+//
+// Run a tiny HTTP server that:
+//   1. Redirects to cryptohopper.com/oauth2/authorize
+//   2. Receives the callback with the auth code
+//   3. Exchanges it for an access token at cryptohopper.com/oauth2/token
+//   4. Calls api.cryptohopper.com/v1/hopper to demonstrate the token works
+//
+// Usage:
+//   export CRYPTOHOPPER_CLIENT_ID=...
+//   export CRYPTOHOPPER_CLIENT_SECRET=...
+//   go run main.go
+//   open http://localhost:3000/auth
+
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+)
+
+const (
+	cryptohopperHost = "https://www.cryptohopper.com"
+	apiHost          = "https://api.cryptohopper.com"
+	port             = "3000"
+)
+
+var (
+	clientID     = os.Getenv("CRYPTOHOPPER_CLIENT_ID")
+	clientSecret = os.Getenv("CRYPTOHOPPER_CLIENT_SECRET")
+	redirectURI  = "http://localhost:" + port + "/callback"
+
+	mu          sync.Mutex
+	accessToken string
+	expectedState string
+)
+
+func main() {
+	if clientID == "" || clientSecret == "" {
+		log.Fatal("Set CRYPTOHOPPER_CLIENT_ID and CRYPTOHOPPER_CLIENT_SECRET")
+	}
+
+	http.HandleFunc("/", handleRoot)
+	http.HandleFunc("/auth", handleAuth)
+	http.HandleFunc("/callback", handleCallback)
+
+	log.Printf("Server started at http://localhost:%s", port)
+	log.Printf("Open http://localhost:%s/auth to begin the OAuth flow", port)
+	log.Fatal(http.ListenAndServe(":"+port, nil))
+}
+
+func handleRoot(w http.ResponseWriter, r *http.Request) {
+	mu.Lock()
+	token := accessToken
+	mu.Unlock()
+
+	if token == "" {
+		fmt.Fprintf(w, `Not logged in. <a href="/auth">Sign in</a>`)
+		return
+	}
+
+	req, _ := http.NewRequest("GET", apiHost+"/v1/hopper", nil)
+	// Cryptohopper Public API v1: `access-token` header (NOT Authorization: Bearer).
+	// See https://www.cryptohopper.com/api-documentation/how-the-api-works
+	req.Header.Set("access-token", token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		http.Error(w, "API call failed: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(body)
+}
+
+func handleAuth(w http.ResponseWriter, r *http.Request) {
+	state := randomState()
+	mu.Lock()
+	expectedState = state
+	mu.Unlock()
+
+	q := url.Values{}
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("response_type", "code")
+	q.Set("scope", "read")
+	q.Set("state", state)
+
+	http.Redirect(w, r, cryptohopperHost+"/oauth2/authorize?"+q.Encode(), http.StatusFound)
+}
+
+func handleCallback(w http.ResponseWriter, r *http.Request) {
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		http.Error(w, "missing code", http.StatusBadRequest)
+		return
+	}
+
+	state := r.URL.Query().Get("state")
+	mu.Lock()
+	want := expectedState
+	mu.Unlock()
+	if state == "" || state != want {
+		http.Error(w, "state mismatch (CSRF protection)", http.StatusBadRequest)
+		return
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("client_id", clientID)
+	form.Set("client_secret", clientSecret)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("code", code)
+
+	resp, err := http.Post(
+		cryptohopperHost+"/oauth2/token",
+		"application/x-www-form-urlencoded",
+		strings.NewReader(form.Encode()),
+	)
+	if err != nil {
+		http.Error(w, "token exchange transport error: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		http.Error(w, fmt.Sprintf("token exchange failed (%d): %s", resp.StatusCode, body), http.StatusBadGateway)
+		return
+	}
+
+	var tok struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(body, &tok); err != nil {
+		http.Error(w, "token exchange parse error: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	mu.Lock()
+	accessToken = tok.AccessToken
+	mu.Unlock()
+
+	http.Redirect(w, r, "/", http.StatusFound)
+}
+
+func randomState() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
+}

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -1,0 +1,31 @@
+# Recipes
+
+Cross-language patterns for common SDK use cases. Each recipe shows the same operation in 2-3 languages so you can copy whichever language fits your stack.
+
+| Recipe | Why | Implementations |
+|--------|-----|-----------------|
+| [`poll-backtest/`](./poll-backtest/) | Backtests run async server-side; you must poll for completion | Node, Python, Go |
+| [`fan-out-positions/`](./fan-out-positions/) | Fetch positions across many hoppers in parallel without tripping rate limits | Node, Python |
+| [`retry-fail-fast/`](./retry-fail-fast/) | Retry transient errors (5xx, network) but fail fast on auth/validation | Node, Python |
+| [`stream-fills/`](./stream-fills/) | Detect new fills via polling — for ad-hoc tools, not production (use webhooks) | Node, Python |
+
+## Why these specifically
+
+These four recipes cover the most common API patterns that aren't obvious from the per-method docs:
+
+- **Polling** — you'll need it for backtests and any other async resource. The pattern is identical regardless of resource.
+- **Bounded fan-out** — naive `Promise.all` / `asyncio.gather` over many hoppers will trip rate limits. The bounded-concurrency pattern is a one-liner once you've seen it.
+- **Smart retry** — auth errors should never retry; transient errors should. The classification is the hard part, not the loop.
+- **Polling for events** — a placeholder until you wire up webhooks. Unavoidable in dev / debug.
+
+Each recipe's README explains the *why* in detail. The code is small enough to copy-paste; the README is the reference.
+
+## Run any of them
+
+```bash
+export CRYPTOHOPPER_TOKEN=your-bearer
+# ... plus any recipe-specific env vars (HOPPER_ID, etc.)
+node recipes/<name>/nodejs.js
+python recipes/<name>/python.py
+go run recipes/<name>/go.go      # where Go is provided
+```

--- a/recipes/fan-out-positions/README.md
+++ b/recipes/fan-out-positions/README.md
@@ -1,0 +1,27 @@
+# Recipe — Fan out: fetch positions for every hopper in parallel
+
+Sequential polling of N hoppers takes N requests serially — slow. Naive `Promise.all` / `asyncio.gather` blasts all N at once and trips the `normal` rate bucket (30 req/min) past ~30 hoppers. The right tool is **bounded concurrency**: at most M requests in flight at a time, where M is well under the rate limit.
+
+## The pattern
+
+1. List all hoppers.
+2. Spawn a worker pool of ~10 concurrent tasks.
+3. Each worker pulls hopper IDs off a queue, calls `hoppers.positions(id)`, returns the result.
+4. Collect results.
+
+## Rate-limit math
+
+- `normal` bucket: 30 req/min ≈ 1 req every 2 seconds in steady state.
+- 10 concurrent workers, each waiting ~200ms per request: 50 req/sec peak — *will* trip the limit on bursts.
+- The SDK auto-retries 429s, so this works *eventually* even under bursts. But you'll be slower than just running 10 workers with explicit per-worker pacing.
+
+For 100+ hoppers, drop concurrency to 5 and add a per-request sleep, or chunk the work.
+
+## Available implementations
+
+| Language | File | Concurrency primitive |
+|----------|------|----------------------|
+| Node.js | [`nodejs.js`](./nodejs.js) | `Promise.all` over N workers consuming a shared index |
+| Python | [`python.py`](./python.py) | `concurrent.futures.ThreadPoolExecutor(max_workers=10)` |
+
+The Go pattern (with `errgroup` + `semaphore`) is similar and works the same way; deferred to a future addition.

--- a/recipes/fan-out-positions/nodejs.js
+++ b/recipes/fan-out-positions/nodejs.js
@@ -1,0 +1,57 @@
+// Fan out: fetch positions for every hopper in parallel, with a concurrency cap.
+//
+// Sequential polling of N hoppers takes N requests serially. Promise.all
+// blasts all N at once and trips the `normal` rate bucket (30 req/min)
+// past ~30 hoppers. The right tool is bounded concurrency.
+//
+// Run:
+//   export CRYPTOHOPPER_TOKEN=your-bearer
+//   node nodejs.js
+
+import { CryptohopperClient, CryptohopperError } from "@cryptohopper/sdk";
+
+const CONCURRENCY = 10;
+const token = process.env.CRYPTOHOPPER_TOKEN;
+if (!token) {
+  console.error("Set CRYPTOHOPPER_TOKEN");
+  process.exit(1);
+}
+
+const ch = new CryptohopperClient({ apiKey: token });
+
+const hoppers = await ch.hoppers.list();
+console.log(`Fetching positions for ${hoppers.length} hoppers, ${CONCURRENCY} at a time…`);
+
+const results = await mapWithConcurrency(hoppers, CONCURRENCY, async (h) => {
+  try {
+    const positions = await ch.hoppers.positions(h.id);
+    return { id: h.id, name: h.name, positions };
+  } catch (e) {
+    if (e instanceof CryptohopperError) {
+      return { id: h.id, name: h.name, error: e.code };
+    }
+    throw e;
+  }
+});
+
+for (const r of results) {
+  if (r.error) {
+    console.log(`hopper ${r.id} (${r.name}): ERROR ${r.error}`);
+  } else {
+    console.log(`hopper ${r.id} (${r.name}): ${r.positions.length} positions`);
+  }
+}
+
+// Bounded-concurrency map: never has more than `n` promises in flight.
+async function mapWithConcurrency(items, n, fn) {
+  const results = new Array(items.length);
+  let i = 0;
+  async function worker() {
+    while (i < items.length) {
+      const idx = i++;
+      results[idx] = await fn(items[idx]);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(n, items.length) }, worker));
+  return results;
+}

--- a/recipes/fan-out-positions/python.py
+++ b/recipes/fan-out-positions/python.py
@@ -1,0 +1,49 @@
+"""Fan out: fetch positions for every hopper in parallel, with a concurrency cap.
+
+Sequential polling of N hoppers takes N requests serially. ThreadPoolExecutor
+with `max_workers` lets us run them concurrently while still respecting
+the API's `normal` rate bucket (30 req/min) — keep `max_workers` modest
+to avoid hammering the limit.
+
+Run:
+    export CRYPTOHOPPER_TOKEN=your-bearer
+    python python.py
+"""
+
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from cryptohopper import CryptohopperClient, CryptohopperError
+
+
+def main() -> None:
+    token = os.environ.get("CRYPTOHOPPER_TOKEN")
+    if not token:
+        print("Set CRYPTOHOPPER_TOKEN", file=sys.stderr)
+        sys.exit(1)
+
+    with CryptohopperClient(api_key=token) as ch:
+        hoppers = ch.hoppers.list()
+        print(f"Fetching positions for {len(hoppers)} hoppers, 10 at a time…")
+
+        with ThreadPoolExecutor(max_workers=10) as pool:
+            futures = {
+                pool.submit(_positions_for, ch, h): h
+                for h in hoppers
+            }
+            for future in as_completed(futures):
+                h = futures[future]
+                try:
+                    positions = future.result()
+                    print(f"hopper {h['id']} ({h.get('name')}): {len(positions)} positions")
+                except CryptohopperError as e:
+                    print(f"hopper {h['id']} ({h.get('name')}): ERROR {e.code}")
+
+
+def _positions_for(ch, h):
+    return ch.hoppers.positions(h["id"])
+
+
+if __name__ == "__main__":
+    main()

--- a/recipes/poll-backtest/README.md
+++ b/recipes/poll-backtest/README.md
@@ -1,0 +1,30 @@
+# Recipe — Poll a backtest until it finishes
+
+Backtests run **asynchronously** server-side. `backtest.create` returns immediately with an ID; the actual computation happens in the background. To get the result, you poll `backtest.get` until `status` is terminal (`"completed"` or `"failed"`).
+
+## The pattern, in any language
+
+1. Submit the backtest with `backtest.create({hopper_id, start_date, end_date})`.
+2. Save the returned `id`.
+3. Loop:
+   - `backtest.get(id)` → check `status`
+   - If `"completed"` or `"failed"`, return the result
+   - Otherwise sleep ~5 seconds and re-check
+
+## Rate-limit note
+
+The `backtest` rate bucket is 1 request per 2 seconds. **5-second polling stays well clear** of the limit. Don't poll faster than that — you'll start eating 429s.
+
+## Available implementations
+
+| Language | File |
+|----------|------|
+| Node.js | [`nodejs.js`](./nodejs.js) |
+| Python | [`python.py`](./python.py) |
+| Go | [`go.go`](./go.go) |
+
+Each takes the same env vars: `CRYPTOHOPPER_TOKEN`, `HOPPER_ID`. Run command is in the file header.
+
+## Picking a backtest range
+
+The example uses Q1 2026. Substitute your own dates as `YYYY-MM-DD`. The server caps backtest spans (typically 2 years); see `backtest.limits()` for your account's quota.

--- a/recipes/poll-backtest/go.go
+++ b/recipes/poll-backtest/go.go
@@ -1,0 +1,74 @@
+// Poll a backtest until it terminates, then print the result.
+//
+// Backtests run async server-side. Backtest.Create returns immediately
+// with an ID; you poll Backtest.Get until Status is "completed" or
+// "failed". The backtest rate bucket is 1 req / 2s — 5-second polling
+// stays well clear.
+//
+// Run (after `go mod tidy`):
+//   export CRYPTOHOPPER_TOKEN=your-bearer
+//   export HOPPER_ID=42
+//   go run go.go
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	cryptohopper "github.com/cryptohopper/cryptohopper-go-sdk"
+)
+
+func mustEnv(name string) string {
+	v := os.Getenv(name)
+	if v == "" {
+		fmt.Fprintln(os.Stderr, "Set", name)
+		os.Exit(1)
+	}
+	return v
+}
+
+func main() {
+	token := mustEnv("CRYPTOHOPPER_TOKEN")
+	hopperID, err := strconv.Atoi(mustEnv("HOPPER_ID"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "HOPPER_ID must be an integer")
+		os.Exit(1)
+	}
+
+	ch, err := cryptohopper.NewClient(token)
+	if err != nil {
+		panic(err)
+	}
+	ctx := context.Background()
+
+	submitted, err := ch.Backtest.Create(ctx, map[string]any{
+		"hopper_id":  hopperID,
+		"start_date": "2026-01-01",
+		"end_date":   "2026-04-01",
+	})
+	if err != nil {
+		panic(err)
+	}
+	btID := submitted["id"]
+	fmt.Printf("Submitted backtest %v\n", btID)
+
+	for {
+		bt, err := ch.Backtest.Get(ctx, fmt.Sprintf("%v", btID))
+		if err != nil {
+			panic(err)
+		}
+		status, _ := bt["status"].(string)
+		fmt.Printf("  status=%s\n", status)
+		if status == "completed" || status == "failed" {
+			pretty, _ := json.MarshalIndent(bt, "", "  ")
+			fmt.Println(string(pretty))
+			return
+		}
+		time.Sleep(5 * time.Second)
+	}
+}

--- a/recipes/poll-backtest/nodejs.js
+++ b/recipes/poll-backtest/nodejs.js
@@ -1,0 +1,49 @@
+// Poll a backtest until it terminates, then print the result.
+//
+// Backtests run async server-side. `backtest.create` returns immediately
+// with an ID; you poll `backtest.get` until `status` is "completed" or
+// "failed". The backtest rate bucket is 1 req / 2s — 5-second polling
+// stays well clear.
+//
+// Run:
+//   export CRYPTOHOPPER_TOKEN=your-bearer
+//   export HOPPER_ID=42
+//   node nodejs.js
+
+import { CryptohopperClient, CryptohopperError } from "@cryptohopper/sdk";
+
+const token = mustEnv("CRYPTOHOPPER_TOKEN");
+const hopperId = Number(mustEnv("HOPPER_ID"));
+
+const ch = new CryptohopperClient({ apiKey: token });
+
+const submitted = await ch.backtest.create({
+  hopper_id: hopperId,
+  start_date: "2026-01-01",
+  end_date: "2026-04-01",
+});
+const btId = submitted.id;
+console.log(`Submitted backtest ${btId}`);
+
+while (true) {
+  const bt = await ch.backtest.get(btId);
+  console.log(`  status=${bt.status}`);
+  if (bt.status === "completed" || bt.status === "failed") {
+    console.log(JSON.stringify(bt, null, 2));
+    break;
+  }
+  await sleep(5_000);
+}
+
+function mustEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`Set ${name}`);
+    process.exit(1);
+  }
+  return v;
+}
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/recipes/poll-backtest/python.py
+++ b/recipes/poll-backtest/python.py
@@ -1,0 +1,52 @@
+"""Poll a backtest until it terminates, then print the result.
+
+Backtests run async server-side. backtest.create returns immediately with
+an ID; you poll backtest.get until status is "completed" or "failed".
+The backtest rate bucket is 1 req / 2s — 5-second polling stays well clear.
+
+Run:
+    export CRYPTOHOPPER_TOKEN=your-bearer
+    export HOPPER_ID=42
+    python python.py
+"""
+
+import json
+import os
+import sys
+import time
+
+from cryptohopper import CryptohopperClient
+
+
+def must_env(name: str) -> str:
+    v = os.environ.get(name)
+    if not v:
+        print(f"Set {name}", file=sys.stderr)
+        sys.exit(1)
+    return v
+
+
+def main() -> None:
+    token = must_env("CRYPTOHOPPER_TOKEN")
+    hopper_id = int(must_env("HOPPER_ID"))
+
+    with CryptohopperClient(api_key=token) as ch:
+        submitted = ch.backtest.create({
+            "hopper_id": hopper_id,
+            "start_date": "2026-01-01",
+            "end_date": "2026-04-01",
+        })
+        bt_id = submitted["id"]
+        print(f"Submitted backtest {bt_id}")
+
+        while True:
+            bt = ch.backtest.get(bt_id)
+            print(f"  status={bt.get('status')}")
+            if bt.get("status") in {"completed", "failed"}:
+                print(json.dumps(bt, indent=2))
+                return
+            time.sleep(5)
+
+
+if __name__ == "__main__":
+    main()

--- a/recipes/retry-fail-fast/README.md
+++ b/recipes/retry-fail-fast/README.md
@@ -1,0 +1,41 @@
+# Recipe — Retry on transient errors, fail fast on auth errors
+
+The SDK already retries 429s with `Retry-After`. You'd wrap *additional* retry on top for **5xx server errors and network errors** — both are transient. But you should **never retry auth/validation errors**: they're not going to fix themselves and each attempt makes the problem worse (logs flooded, rate-limit budget burnt).
+
+## The classification
+
+| Error code | Retry? | Reason |
+|------------|--------|--------|
+| `UNAUTHORIZED` | ❌ no | Token's bad. Won't get better. Re-issue. |
+| `FORBIDDEN` | ❌ no | Missing scope or IP allowlist. Won't get better. |
+| `NOT_FOUND` | ❌ no | Resource doesn't exist. |
+| `VALIDATION_ERROR` | ❌ no | Bad request. Fix the call. |
+| `DEVICE_UNAUTHORIZED` | ❌ no | Mobile-flow only. |
+| `RATE_LIMITED` | (handled by SDK) | SDK auto-retries with `Retry-After`. |
+| `SERVER_ERROR` | ✅ yes | Upstream blip. Try again. |
+| `SERVICE_UNAVAILABLE` | ✅ yes | Maintenance window. Try again. |
+| `NETWORK_ERROR` | ✅ yes | DNS / TLS / connection refused. |
+| `TIMEOUT` | ✅ maybe | Depends on your latency budget. |
+
+## The pattern
+
+```
+for attempt in 0..maxAttempts:
+    try:
+        return fn()
+    except CryptohopperError as e:
+        if e.code in FAIL_FAST_CODES: raise
+        if last_attempt: raise
+        sleep(backoff(attempt))
+```
+
+Backoff is exponential (`500ms × 2^attempt` is a sensible default) — no need to add jitter for a single client; the server's distribution across users provides plenty.
+
+## Available implementations
+
+| Language | File |
+|----------|------|
+| Node.js | [`nodejs.js`](./nodejs.js) |
+| Python | [`python.py`](./python.py) |
+
+Same shape in every language — `withRetry` / `with_retry` higher-order function around a closure.

--- a/recipes/retry-fail-fast/nodejs.js
+++ b/recipes/retry-fail-fast/nodejs.js
@@ -1,0 +1,45 @@
+// Retry on transient errors, fail fast on auth/validation errors.
+//
+// The SDK auto-retries 429s. For 5xx and network errors you may want a
+// tighter retry. Auth errors should *never* be retried — they only get
+// worse on each attempt (and 401 in particular won't change).
+//
+// Run:
+//   export CRYPTOHOPPER_TOKEN=your-bearer
+//   node nodejs.js
+
+import { CryptohopperClient, CryptohopperError } from "@cryptohopper/sdk";
+
+const FAIL_FAST_CODES = new Set([
+  "UNAUTHORIZED",
+  "FORBIDDEN",
+  "NOT_FOUND",
+  "VALIDATION_ERROR",
+  "DEVICE_UNAUTHORIZED",
+]);
+
+async function withRetry(fn, { maxAttempts = 3 } = {}) {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (e) {
+      const isFailFast =
+        e instanceof CryptohopperError && FAIL_FAST_CODES.has(e.code);
+      if (isFailFast) throw e;
+      if (attempt + 1 === maxAttempts) throw e;
+      const backoff = 500 * 2 ** attempt;
+      console.error(`  retry ${attempt + 1}/${maxAttempts} after ${backoff}ms (${e.code ?? e.message})`);
+      await new Promise((r) => setTimeout(r, backoff));
+    }
+  }
+}
+
+const token = process.env.CRYPTOHOPPER_TOKEN;
+if (!token) {
+  console.error("Set CRYPTOHOPPER_TOKEN");
+  process.exit(1);
+}
+
+const ch = new CryptohopperClient({ apiKey: token });
+const me = await withRetry(() => ch.user.get());
+console.log(`Logged in as ${me.email ?? me.username ?? me.id}`);

--- a/recipes/retry-fail-fast/python.py
+++ b/recipes/retry-fail-fast/python.py
@@ -1,0 +1,62 @@
+"""Retry on transient errors, fail fast on auth/validation errors.
+
+The SDK auto-retries 429s. For 5xx and network errors you may want a
+tighter retry. Auth errors should *never* be retried — they only get
+worse on each attempt.
+
+Run:
+    export CRYPTOHOPPER_TOKEN=your-bearer
+    python python.py
+"""
+
+import os
+import sys
+import time
+from typing import Callable, TypeVar
+
+from cryptohopper import CryptohopperClient, CryptohopperError
+
+T = TypeVar("T")
+
+FAIL_FAST_CODES = {
+    "UNAUTHORIZED",
+    "FORBIDDEN",
+    "NOT_FOUND",
+    "VALIDATION_ERROR",
+    "DEVICE_UNAUTHORIZED",
+}
+
+
+def with_retry(fn: Callable[[], T], *, max_attempts: int = 3) -> T:
+    last_exc: Exception | None = None
+    for attempt in range(max_attempts):
+        try:
+            return fn()
+        except CryptohopperError as e:
+            if e.code in FAIL_FAST_CODES:
+                raise
+            last_exc = e
+            if attempt + 1 == max_attempts:
+                raise
+            backoff_s = 0.5 * (2 ** attempt)
+            print(
+                f"  retry {attempt + 1}/{max_attempts} after {backoff_s:.1f}s ({e.code})",
+                file=sys.stderr,
+            )
+            time.sleep(backoff_s)
+    raise last_exc or RuntimeError("retry budget exhausted")
+
+
+def main() -> None:
+    token = os.environ.get("CRYPTOHOPPER_TOKEN")
+    if not token:
+        print("Set CRYPTOHOPPER_TOKEN", file=sys.stderr)
+        sys.exit(1)
+
+    with CryptohopperClient(api_key=token) as ch:
+        me = with_retry(lambda: ch.user.get())
+        print(f"Logged in as {me.get('email') or me.get('username') or me.get('id')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/recipes/stream-fills/README.md
+++ b/recipes/stream-fills/README.md
@@ -1,0 +1,29 @@
+# Recipe — Stream new fills
+
+Cryptohopper's public API doesn't expose a fills WebSocket. For tooling that wants near-real-time fill notifications, the canonical pattern is **poll orders, dedupe by id, emit on transition to `"filled"`**.
+
+This works for dashboards, ad-hoc CLI tools, and any case where webhooks are overkill. **For production, register a webhook** ([`webhooks/`](../../webhooks/)) — push beats poll for event delivery.
+
+## The pattern
+
+1. Maintain a set of already-seen order IDs in memory.
+2. Loop:
+   - `hoppers.orders(hopper_id)` — list recent orders
+   - For each order: if `id ∉ seen` and `status == "filled"`, emit it
+   - Add `id` to `seen` regardless (so we don't keep re-checking it)
+3. Sleep ~10 seconds between polls.
+
+## Rate-limit note
+
+Polling one hopper every 10 seconds is 6 req/min — well under the `normal` bucket (30 req/min). For multiple hoppers, share the same poll loop and increase the interval rather than running parallel pollers.
+
+## Restarting
+
+The `seen` set is in-memory only. On restart, the first poll re-reads recent orders and may re-emit fills it had already emitted before the restart. For exactly-once delivery you need a persistent dedupe store — webhooks are a much better answer.
+
+## Available implementations
+
+| Language | File |
+|----------|------|
+| Node.js | [`nodejs.js`](./nodejs.js) |
+| Python | [`python.py`](./python.py) |

--- a/recipes/stream-fills/nodejs.js
+++ b/recipes/stream-fills/nodejs.js
@@ -1,0 +1,50 @@
+// Stream new fills: poll a hopper's orders and emit each newly-filled one.
+//
+// Cryptohopper doesn't expose a fills WebSocket on the public API, so the
+// canonical pattern is "poll orders, dedupe by id, emit on transition to
+// 'filled'". For production you'd register a webhook instead — see
+// ../../webhooks/. This recipe is for ad-hoc tooling and dashboards.
+//
+// Run:
+//   export CRYPTOHOPPER_TOKEN=your-bearer
+//   export HOPPER_ID=42
+//   node nodejs.js
+
+import { CryptohopperClient } from "@cryptohopper/sdk";
+
+const POLL_MS = 10_000;
+const token = mustEnv("CRYPTOHOPPER_TOKEN");
+const hopperId = Number(mustEnv("HOPPER_ID"));
+
+const ch = new CryptohopperClient({ apiKey: token });
+const seen = new Set();
+
+console.log(`Watching hopper ${hopperId} for fills (polling every ${POLL_MS}ms)…`);
+
+while (true) {
+  try {
+    const orders = (await ch.hoppers.orders(hopperId)) ?? [];
+    for (const o of orders) {
+      const id = String(o.id ?? "");
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      if (o.status === "filled") {
+        console.log(
+          `Fill: ${o.market} ${o.type} ${o.amount} @ ${o.price} (id=${id})`,
+        );
+      }
+    }
+  } catch (e) {
+    console.error("poll error:", e.code ?? e.message);
+  }
+  await new Promise((r) => setTimeout(r, POLL_MS));
+}
+
+function mustEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`Set ${name}`);
+    process.exit(1);
+  }
+  return v;
+}

--- a/recipes/stream-fills/python.py
+++ b/recipes/stream-fills/python.py
@@ -1,0 +1,58 @@
+"""Stream new fills: poll a hopper's orders and emit each newly-filled one.
+
+Cryptohopper doesn't expose a fills WebSocket on the public API, so the
+canonical pattern is "poll orders, dedupe by id, emit on transition to
+'filled'". For production you'd register a webhook instead — see
+../../webhooks/. This recipe is for ad-hoc tooling and dashboards.
+
+Run:
+    export CRYPTOHOPPER_TOKEN=your-bearer
+    export HOPPER_ID=42
+    python python.py
+"""
+
+import os
+import sys
+import time
+
+from cryptohopper import CryptohopperClient, CryptohopperError
+
+POLL_S = 10
+
+
+def must_env(name: str) -> str:
+    v = os.environ.get(name)
+    if not v:
+        print(f"Set {name}", file=sys.stderr)
+        sys.exit(1)
+    return v
+
+
+def main() -> None:
+    token = must_env("CRYPTOHOPPER_TOKEN")
+    hopper_id = int(must_env("HOPPER_ID"))
+    seen: set[str] = set()
+
+    print(f"Watching hopper {hopper_id} for fills (polling every {POLL_S}s)…")
+
+    with CryptohopperClient(api_key=token) as ch:
+        while True:
+            try:
+                orders = ch.hoppers.orders(hopper_id) or []
+                for o in orders:
+                    oid = str(o.get("id", ""))
+                    if not oid or oid in seen:
+                        continue
+                    seen.add(oid)
+                    if o.get("status") == "filled":
+                        print(
+                            f"Fill: {o.get('market')} {o.get('type')} "
+                            f"{o.get('amount')} @ {o.get('price')} (id={oid})"
+                        )
+            except CryptohopperError as e:
+                print(f"poll error: {e.code}", file=sys.stderr)
+            time.sleep(POLL_S)
+
+
+if __name__ == "__main__":
+    main()

--- a/webhooks/nodejs/README.md
+++ b/webhooks/nodejs/README.md
@@ -1,0 +1,49 @@
+# Node.js webhook receiver
+
+A minimal Express server that:
+
+1. Listens on `/cryptohopper`
+2. Parses the JSON body
+3. Verifies an HMAC-SHA256 signature header if a shared secret is configured
+4. Dispatches by event type
+
+## Run it
+
+```bash
+export CRYPTOHOPPER_WEBHOOK_SECRET=your-shared-secret  # optional but recommended
+npm install
+npm start
+```
+
+Then expose `http://localhost:3000/cryptohopper` to the public internet (e.g. via [`ngrok http 3000`](https://ngrok.com/) during development) and register that URL with Cryptohopper:
+
+```bash
+cryptohopper webhooks create --url https://your-ngrok-id.ngrok.app/cryptohopper --event order_filled
+```
+
+## What it shows
+
+- `express.json({ verify: ... })` to capture the raw body for signature verification *before* it's parsed
+- HMAC-SHA256 verification with `crypto.timingSafeEqual` to defeat timing attacks
+- Event dispatch via a `switch` — easy to extend with new event types
+
+## Signature verification — why and how
+
+If you've configured a webhook secret on your Cryptohopper app, the server signs every webhook body with HMAC-SHA256 and sends the digest in `X-Cryptohopper-Signature`. The receiver re-computes the digest from the raw body and the shared secret, then compares with `timingSafeEqual` (constant-time, defeats timing attacks).
+
+If `CRYPTOHOPPER_WEBHOOK_SECRET` isn't set, this sample skips verification and logs a warning. **Always** configure a secret in production.
+
+## Hardening checklist
+
+- [x] Constant-time signature compare
+- [ ] Timestamp tolerance (reject webhooks > 5 min old) — not implemented here; depends on whether the server includes a timestamp in the signed payload.
+- [ ] Replay protection (stash event IDs, reject duplicates) — production receivers should idempotency-key by event ID.
+- [ ] Rate limiting (e.g. `express-rate-limit`) — protect against abuse if your webhook URL leaks.
+
+## Production notes
+
+For real workloads:
+
+- Run multiple receiver replicas behind a load balancer.
+- Persist a "last seen event ID" per webhook in your DB to defeat replays.
+- Acknowledge with 200 *immediately*; do the actual work async (push to a queue). Cryptohopper will retry slow webhooks and you don't want to tip into the retry loop.

--- a/webhooks/nodejs/package.json
+++ b/webhooks/nodejs/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "cryptohopper-webhook-receiver-nodejs",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "start": "node receiver.js"
+  },
+  "dependencies": {
+    "express": "^4.21.0"
+  }
+}

--- a/webhooks/nodejs/receiver.js
+++ b/webhooks/nodejs/receiver.js
@@ -1,0 +1,79 @@
+// Cryptohopper webhook receiver — Node.js (Express).
+//
+// Listens on /cryptohopper, parses the JSON body, and dispatches by
+// event type. Verifies an HMAC-SHA256 signature header if a webhook
+// secret is configured (recommended; see notes below).
+//
+// Run:
+//   export CRYPTOHOPPER_WEBHOOK_SECRET=optional-shared-secret
+//   npm install
+//   node receiver.js
+
+import express from "express";
+import crypto from "node:crypto";
+
+const PORT = process.env.PORT ?? 3000;
+const SECRET = process.env.CRYPTOHOPPER_WEBHOOK_SECRET ?? "";
+
+const app = express();
+// Capture the raw body so we can verify the signature.
+app.use(
+  express.json({
+    verify: (req, _res, buf) => {
+      req.rawBody = buf;
+    },
+  }),
+);
+
+app.post("/cryptohopper", (req, res) => {
+  if (SECRET) {
+    const sig = req.get("x-cryptohopper-signature") ?? "";
+    if (!verifySignature(req.rawBody, sig, SECRET)) {
+      console.error("invalid signature, rejecting");
+      return res.status(401).send("invalid signature");
+    }
+  }
+
+  const { event, payload } = req.body ?? {};
+  console.log(`[${new Date().toISOString()}] event=${event}`);
+  console.log(JSON.stringify(payload, null, 2));
+
+  switch (event) {
+    case "order_filled":
+      handleOrderFilled(payload);
+      break;
+    case "order_cancelled":
+      handleOrderCancelled(payload);
+      break;
+    default:
+      console.log(`  (no handler for event=${event})`);
+  }
+
+  res.status(200).send("ok");
+});
+
+function handleOrderFilled(p) {
+  console.log(`  → fill: ${p.market} ${p.type} ${p.amount} @ ${p.price}`);
+}
+function handleOrderCancelled(p) {
+  console.log(`  → cancelled: order ${p.id}`);
+}
+
+function verifySignature(rawBody, headerSig, secret) {
+  if (!headerSig) return false;
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(rawBody)
+    .digest("hex");
+  // Constant-time compare to defeat timing attacks.
+  const a = Buffer.from(headerSig);
+  const b = Buffer.from(expected);
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+app.listen(PORT, () => {
+  console.log(`Webhook receiver listening on http://localhost:${PORT}/cryptohopper`);
+  if (!SECRET) {
+    console.warn("⚠ CRYPTOHOPPER_WEBHOOK_SECRET not set — signature verification skipped.");
+  }
+});


### PR DESCRIPTION
## Summary

Builds on #12 (now merged). Adds the cross-language and ops surface that makes the repo useful for someone past the hello-world stage.

(Originally opened as #13 stacked on the PR #12 branch; GitHub auto-closed it when that parent branch was deleted on merge. Same content, rebased clean onto master.)

## What's in this PR

### \`recipes/\` — cross-language patterns
| Recipe | Why it matters | Languages |
|--------|----------------|-----------|
| [\`poll-backtest/\`](./recipes/poll-backtest/) | Backtests are async; the polling pattern is the same shape for any future async resource | Node, Python, Go |
| [\`fan-out-positions/\`](./recipes/fan-out-positions/) | Bounded concurrency for many-hopper queries — naive \`Promise.all\` trips rate limits | Node, Python |
| [\`retry-fail-fast/\`](./recipes/retry-fail-fast/) | Retry transient errors, but never auth/validation. Classification matters more than the loop | Node, Python |
| [\`stream-fills/\`](./recipes/stream-fills/) | Polling-based fill detection (no fills WebSocket); placeholder until you wire up webhooks | Node, Python |

Each recipe README explains the *why* (rate limits, exactly-once delivery, retry classification).

### \`oauth/go/\` — Go OAuth flow
Stdlib \`net/http\` only — no third-party deps. CSRF state via \`crypto/rand\`. ~150 lines.

### \`webhooks/nodejs/\` — Express receiver
HMAC-SHA256 signature verification with \`crypto.timingSafeEqual\`. Captures raw body before JSON parse so signature math works. Production-hardening checklist in the README.

### \`cli/\` — Bash + jq scripts
- \`monitor-positions.sh\` — live position dashboard, \`watch\`-style refresh
- \`batch-backtests.sh\` — submit + poll backtests for every hopper

### Root README
Drops the "coming in the next batch" markers; adds Go OAuth link.

## Diff stat
24 files changed, +1179 / -3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)